### PR TITLE
Improve countDocuments query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,19 @@ function paginate(query, options, callback) {
     skip = offset;
   }
 
-  const countPromise = this.countDocuments(query).exec();
+  const countQuery = Object.keys(query)
+    .reduce((acc, curr) => {
+      if (
+        curr === 'limit' ||
+        curr === 'skip' ||
+        curr === 'hint' ||
+        curr === 'maxTimeMS'
+      ) {
+        acc[curr] = query[curr]
+      }
+      return acc
+    }, {})
+  const countPromise = this.countDocuments(countQuery).exec();
 
   if (limit) {
     const mQuery = this.find(query, projection, findOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -101,19 +101,7 @@ function paginate(query, options, callback) {
     skip = offset;
   }
 
-  const countQuery = Object.keys(query)
-    .reduce((acc, curr) => {
-      if (
-        curr === 'limit' ||
-        curr === 'skip' ||
-        curr === 'hint' ||
-        curr === 'maxTimeMS'
-      ) {
-        acc[curr] = query[curr]
-      }
-      return acc
-    }, {})
-  const countPromise = this.countDocuments(countQuery).exec();
+  const countPromise = this.find(query).exec();
 
   if (limit) {
     const mQuery = this.find(query, projection, findOptions);
@@ -149,7 +137,7 @@ function paginate(query, options, callback) {
     .then((values) => {
       const [count, docs] = values;
       const meta = {
-        [labelTotal]: count,
+        [labelTotal]: count.length,
         [labelLimit]: limit
       };
       let result = {};


### PR DESCRIPTION
This change makes the countDocuments() query bullet proof against invalid arguments and doesn`t throw non-helpful errors.

I followed the official documentation to validate the properties on countDocuments() query:

> https://docs.mongodb.com/manual/reference/method/db.collection.countDocuments/